### PR TITLE
feat: add placement support to migration validating stage

### DIFF
--- a/agent/pkg/spec/migration/migration_from_syncer_test.go
+++ b/agent/pkg/spec/migration/migration_from_syncer_test.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	clusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
 	operatorv1 "open-cluster-management.io/api/operator/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -48,6 +49,9 @@ func TestMigrationSourceHubSyncer(t *testing.T) {
 	}
 	if err := clusterv1.AddToScheme(scheme); err != nil {
 		t.Fatalf("Failed to add clusterv1 to scheme: %v", err)
+	}
+	if err := clusterv1beta1.AddToScheme(scheme); err != nil {
+		t.Fatalf("Failed to add clusterv1beta1 to scheme: %v", err)
 	}
 	if err := operatorv1.AddToScheme(scheme); err != nil {
 		t.Fatalf("Failed to add operatorv1 to scheme: %v", err)
@@ -626,4 +630,251 @@ func (m *ProducerMock) SendEvent(ctx context.Context, evt cloudevents.Event) err
 
 func (m *ProducerMock) Reconnect(config *transport.TransportInternalConfig, topic string) error {
 	return nil
+}
+
+// TestValidating tests the validating phase of migration
+func TestValidating(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	if err := clusterv1beta1.AddToScheme(scheme); err != nil {
+		t.Fatalf("Failed to add clusterv1beta1 to scheme: %v", err)
+	}
+
+	cases := []struct {
+		name                 string
+		migrationBundle      *migration.MigrationSourceBundle
+		initObjects          []client.Object
+		expectedClusters     []string
+		expectedError        bool
+		expectedErrorMessage string
+	}{
+		{
+			name: "Should get clusters from placement decisions successfully",
+			migrationBundle: &migration.MigrationSourceBundle{
+				MigrationId:   "test-migration-123",
+				PlacementName: "test-placement",
+			},
+			initObjects: []client.Object{
+				&clusterv1beta1.PlacementDecision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-placement-decision-1",
+						Namespace: "default",
+						Labels: map[string]string{
+							clusterv1beta1.PlacementLabel: "test-placement",
+						},
+					},
+					Status: clusterv1beta1.PlacementDecisionStatus{
+						Decisions: []clusterv1beta1.ClusterDecision{
+							{ClusterName: "cluster1"},
+							{ClusterName: "cluster2"},
+						},
+					},
+				},
+				&clusterv1beta1.PlacementDecision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-placement-decision-2",
+						Namespace: "default",
+						Labels: map[string]string{
+							clusterv1beta1.PlacementLabel: "test-placement",
+						},
+					},
+					Status: clusterv1beta1.PlacementDecisionStatus{
+						Decisions: []clusterv1beta1.ClusterDecision{
+							{ClusterName: "cluster3"},
+						},
+					},
+				},
+			},
+			expectedClusters: []string{"cluster1", "cluster2", "cluster3"},
+			expectedError:    false,
+		},
+		{
+			name: "Should handle empty placement decisions",
+			migrationBundle: &migration.MigrationSourceBundle{
+				MigrationId:   "test-migration-456",
+				PlacementName: "empty-placement",
+			},
+			initObjects:      []client.Object{},
+			expectedClusters: nil, // Returns nil when no placement decisions found
+			expectedError:    false,
+		},
+		{
+			name: "Should handle no placement name provided",
+			migrationBundle: &migration.MigrationSourceBundle{
+				MigrationId:   "test-migration-789",
+				PlacementName: "",
+			},
+			initObjects:      []client.Object{},
+			expectedClusters: nil,
+			expectedError:    false,
+		},
+		{
+			name: "Should filter out empty cluster names",
+			migrationBundle: &migration.MigrationSourceBundle{
+				MigrationId:   "test-migration-filter",
+				PlacementName: "filter-placement",
+			},
+			initObjects: []client.Object{
+				&clusterv1beta1.PlacementDecision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "filter-placement-decision",
+						Namespace: "default",
+						Labels: map[string]string{
+							clusterv1beta1.PlacementLabel: "filter-placement",
+						},
+					},
+					Status: clusterv1beta1.PlacementDecisionStatus{
+						Decisions: []clusterv1beta1.ClusterDecision{
+							{ClusterName: "cluster1"},
+							{ClusterName: ""}, // Empty cluster name should be filtered out
+							{ClusterName: "cluster2"},
+						},
+					},
+				},
+			},
+			expectedClusters: []string{"cluster1", "cluster2"},
+			expectedError:    false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(c.initObjects...).Build()
+
+			syncer := &MigrationSourceSyncer{
+				client: fakeClient,
+			}
+
+			// Create a copy of the migration bundle to avoid modifying the original
+			bundle := &migration.MigrationSourceBundle{
+				MigrationId:     c.migrationBundle.MigrationId,
+				PlacementName:   c.migrationBundle.PlacementName,
+				ManagedClusters: c.migrationBundle.ManagedClusters,
+			}
+
+			err := syncer.validating(ctx, bundle)
+
+			if c.expectedError {
+				assert.NotNil(t, err)
+				if c.expectedErrorMessage != "" {
+					assert.Contains(t, err.Error(), c.expectedErrorMessage)
+				}
+			} else {
+				assert.Nil(t, err)
+				if c.migrationBundle.PlacementName != "" {
+					// When placement name is provided, ManagedClusters should be set to whatever getClustersFromPlacementDecisions returns
+					assert.Equal(t, c.expectedClusters, bundle.ManagedClusters)
+				} else {
+					// When placement name is empty, ManagedClusters should remain unchanged
+					assert.Equal(t, c.migrationBundle.ManagedClusters, bundle.ManagedClusters)
+				}
+			}
+		})
+	}
+}
+
+// TestGetClustersFromPlacementDecisions tests the getClustersFromPlacementDecisions function
+func TestGetClustersFromPlacementDecisions(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+
+	if err := clusterv1beta1.AddToScheme(scheme); err != nil {
+		t.Fatalf("Failed to add clusterv1beta1 to scheme: %v", err)
+	}
+
+	cases := []struct {
+		name                 string
+		placementName        string
+		initObjects          []client.Object
+		expectedClusters     []string
+		expectedError        bool
+		expectedErrorMessage string
+	}{
+		{
+			name:          "Should return clusters from multiple placement decisions",
+			placementName: "test-placement",
+			initObjects: []client.Object{
+				&clusterv1beta1.PlacementDecision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-placement-decision-1",
+						Namespace: "default",
+						Labels: map[string]string{
+							clusterv1beta1.PlacementLabel: "test-placement",
+						},
+					},
+					Status: clusterv1beta1.PlacementDecisionStatus{
+						Decisions: []clusterv1beta1.ClusterDecision{
+							{ClusterName: "cluster1"},
+							{ClusterName: "cluster2"},
+						},
+					},
+				},
+				&clusterv1beta1.PlacementDecision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-placement-decision-2",
+						Namespace: "default",
+						Labels: map[string]string{
+							clusterv1beta1.PlacementLabel: "test-placement",
+						},
+					},
+					Status: clusterv1beta1.PlacementDecisionStatus{
+						Decisions: []clusterv1beta1.ClusterDecision{
+							{ClusterName: "cluster3"},
+						},
+					},
+				},
+			},
+			expectedClusters: []string{"cluster1", "cluster2", "cluster3"},
+			expectedError:    false,
+		},
+		{
+			name:             "Should return empty list when no placement decisions found",
+			placementName:    "nonexistent-placement",
+			initObjects:      []client.Object{},
+			expectedClusters: nil, // Returns nil when no clusters found
+			expectedError:    false,
+		},
+		{
+			name:          "Should handle placement decisions with no clusters",
+			placementName: "empty-placement",
+			initObjects: []client.Object{
+				&clusterv1beta1.PlacementDecision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "empty-placement-decision",
+						Namespace: "default",
+						Labels: map[string]string{
+							clusterv1beta1.PlacementLabel: "empty-placement",
+						},
+					},
+					Status: clusterv1beta1.PlacementDecisionStatus{
+						Decisions: []clusterv1beta1.ClusterDecision{},
+					},
+				},
+			},
+			expectedClusters: nil, // Returns nil when no clusters found
+			expectedError:    false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(c.initObjects...).Build()
+
+			syncer := &MigrationSourceSyncer{
+				client: fakeClient,
+			}
+
+			clusters, err := syncer.getClustersFromPlacementDecisions(ctx, c.placementName)
+
+			if c.expectedError {
+				assert.NotNil(t, err)
+				if c.expectedErrorMessage != "" {
+					assert.Contains(t, err.Error(), c.expectedErrorMessage)
+				}
+			} else {
+				assert.Nil(t, err)
+				assert.Equal(t, c.expectedClusters, clusters)
+			}
+		})
+	}
 }

--- a/manager/pkg/migration/migration_cleaning.go
+++ b/manager/pkg/migration/migration_cleaning.go
@@ -58,7 +58,8 @@ func (m *ClusterMigrationController) cleaning(ctx context.Context,
 
 	// cleanup the source hub: cleaning or failed state
 	fromHub := mcm.Spec.From
-	clusters := mcm.Spec.IncludedManagedClusters
+	clusters := GetClusterList(string(mcm.UID))
+
 	bootstrapSecret := getBootstrapSecret(mcm.Spec.To, nil)
 	if !GetStarted(string(mcm.GetUID()), fromHub, migrationv1alpha1.PhaseCleaning) {
 		if err := m.sendEventToSourceHub(ctx, fromHub, mcm, migrationv1alpha1.PhaseCleaning, clusters,

--- a/manager/pkg/migration/migration_controller.go
+++ b/manager/pkg/migration/migration_controller.go
@@ -51,19 +51,16 @@ var log = logger.DefaultZapLogger()
 type ClusterMigrationController struct {
 	client.Client
 	transport.Producer
-	BootstrapSecret *corev1.Secret
-	managerConfigs  *configs.ManagerConfig
-	EventRecorder   record.EventRecorder
+	EventRecorder record.EventRecorder
 }
 
 func NewMigrationController(client client.Client, producer transport.Producer,
 	managerConfig *configs.ManagerConfig, eventRecorder record.EventRecorder,
 ) *ClusterMigrationController {
 	return &ClusterMigrationController{
-		Client:         client,
-		Producer:       producer,
-		managerConfigs: managerConfig,
-		EventRecorder:  eventRecorder,
+		Client:        client,
+		Producer:      producer,
+		EventRecorder: eventRecorder,
 	}
 }
 

--- a/manager/pkg/migration/migration_deploying.go
+++ b/manager/pkg/migration/migration_deploying.go
@@ -30,7 +30,7 @@ func (m *ClusterMigrationController) deploying(ctx context.Context,
 		mcm.Status.Phase != migrationv1alpha1.PhaseDeploying {
 		return false, nil
 	}
-	log.Info("migration deploying")
+	log.Infof("migration %v deploying", mcm.Name)
 
 	condition := metav1.Condition{
 		Type:    migrationv1alpha1.ConditionTypeDeployed,
@@ -43,7 +43,7 @@ func (m *ClusterMigrationController) deploying(ctx context.Context,
 	defer m.handleStatusWithRollback(ctx, mcm, &condition, &nextPhase, migrationStageTimeout)
 
 	fromHub := mcm.Spec.From
-	clusters := mcm.Spec.IncludedManagedClusters
+	clusters := GetClusterList(string(mcm.UID))
 
 	// 1. source hub: start and wait the confirmation
 	if !GetStarted(string(mcm.GetUID()), fromHub, migrationv1alpha1.PhaseDeploying) {

--- a/manager/pkg/migration/migration_eventstatus.go
+++ b/manager/pkg/migration/migration_eventstatus.go
@@ -6,8 +6,9 @@ import (
 )
 
 var (
-	migrationStatuses = make(map[string]*MigrationStatus)
-	mu                sync.RWMutex // optional: for concurrent access
+	migrationStatuses           = make(map[string]*MigrationStatus)
+	mu                          sync.RWMutex // optional: for concurrent access
+	currentMigrationClusterList = make(map[string][]string)
 )
 
 type MigrationStatus struct {
@@ -57,6 +58,7 @@ func RemoveMigrationStatus(migrationId string) {
 		return
 	}
 	delete(migrationStatuses, migrationId)
+	delete(currentMigrationClusterList, migrationId)
 	log.Infof("clean up migration status for migrationId: %s", migrationId)
 }
 
@@ -87,8 +89,8 @@ func getStageState(migrationId, hub, phase string) *StageState {
 
 // SetStarted sets the status of the given stage to started for the hub cluster
 func SetStarted(migrationId, hub, phase string) {
-	mu.RLock()
-	defer mu.RUnlock()
+	mu.Lock()
+	defer mu.Unlock()
 	if p := getStageState(migrationId, hub, phase); p != nil {
 		p.started = true
 	}
@@ -96,16 +98,23 @@ func SetStarted(migrationId, hub, phase string) {
 
 // SetFinished sets the status of the given stage to finished for the hub cluster
 func SetFinished(migrationId, hub, phase string) {
-	mu.RLock()
-	defer mu.RUnlock()
+	mu.Lock()
+	defer mu.Unlock()
 	if p := getStageState(migrationId, hub, phase); p != nil {
 		p.finished = true
 	}
 }
 
+// SetClusterList sets the managed clusters list for the given migration stage
+func SetClusterList(migrationId string, managedClusters []string) {
+	mu.Lock()
+	defer mu.Unlock()
+	currentMigrationClusterList[migrationId] = managedClusters
+}
+
 func SetErrorMessage(migrationId, hub, phase, errMessage string) {
-	mu.RLock()
-	defer mu.RUnlock()
+	mu.Lock()
+	defer mu.Unlock()
 	if p := getStageState(migrationId, hub, phase); p != nil {
 		p.error = errMessage
 	}
@@ -138,4 +147,18 @@ func GetErrorMessage(migrationId, hub, phase string) string {
 		return p.error
 	}
 	return ""
+}
+
+// GetClusterList returns the managed clusters list for the given migration stage
+func GetClusterList(migrationId string) []string {
+	mu.RLock()
+	defer mu.RUnlock()
+	if currentMigrationClusterList == nil {
+		return nil
+	}
+	clusters, ok := currentMigrationClusterList[migrationId]
+	if ok {
+		return clusters
+	}
+	return nil
 }

--- a/manager/pkg/migration/migration_initializing.go
+++ b/manager/pkg/migration/migration_initializing.go
@@ -48,7 +48,7 @@ func (m *ClusterMigrationController) initializing(ctx context.Context,
 		mcm.Status.Phase != migrationv1alpha1.PhaseInitializing {
 		return false, nil
 	}
-	log.Info("migration initializing started")
+	log.Infof("migration %v initializing started", mcm.Name)
 
 	condition := metav1.Condition{
 		Type:    migrationv1alpha1.ConditionTypeInitialized,
@@ -98,7 +98,8 @@ func (m *ClusterMigrationController) initializing(ctx context.Context,
 
 	// 3. Send event to Source Hub
 	fromHub := mcm.Spec.From
-	clusters := mcm.Spec.IncludedManagedClusters
+	clusters := GetClusterList(string(mcm.UID))
+
 	if !GetStarted(string(mcm.GetUID()), fromHub, migrationv1alpha1.PhaseInitializing) {
 		err := m.sendEventToSourceHub(ctx, fromHub, mcm, migrationv1alpha1.PhaseInitializing, clusters,
 			bootstrapSecret, "")
@@ -188,6 +189,7 @@ func (m *ClusterMigrationController) sendEventToSourceHub(ctx context.Context, f
 		MigrationId:     string(migration.GetUID()),
 		Stage:           stage,
 		ToHub:           migration.Spec.To,
+		PlacementName:   migration.Spec.IncludedManagedClustersPlacementRef,
 		ManagedClusters: managedClusters,
 		BootstrapSecret: bootstrapSecret,
 		RollbackStage:   rollbackStage,

--- a/manager/pkg/migration/migration_registering.go
+++ b/manager/pkg/migration/migration_registering.go
@@ -31,7 +31,7 @@ func (m *ClusterMigrationController) registering(ctx context.Context,
 		return false, nil
 	}
 
-	log.Info("migration registering")
+	log.Info("migration %v registering", mcm.Name)
 
 	condition := metav1.Condition{
 		Type:    migrationv1alpha1.ConditionTypeRegistered,
@@ -44,7 +44,8 @@ func (m *ClusterMigrationController) registering(ctx context.Context,
 	defer m.handleStatusWithRollback(ctx, mcm, &condition, &nextPhase, registeringTimeout)
 
 	fromHub := mcm.Spec.From
-	clusters := mcm.Spec.IncludedManagedClusters
+	clusters := GetClusterList(string(mcm.UID))
+
 	if !GetStarted(string(mcm.GetUID()), fromHub, migrationv1alpha1.PhaseRegistering) {
 		log.Infof("migration registering: %s", fromHub)
 		// notify the source hub to start registering

--- a/manager/pkg/migration/migration_rollbacking.go
+++ b/manager/pkg/migration/migration_rollbacking.go
@@ -37,7 +37,7 @@ func (m *ClusterMigrationController) rollbacking(ctx context.Context,
 		return false, nil
 	}
 
-	log.Info("migration rollbacking started")
+	log.Infof("migration %s rollbacking started", mcm.Name)
 
 	// Determine the failed stage to provide context in messages
 	failedStage := m.determineFailedStage(ctx, mcm)
@@ -54,7 +54,8 @@ func (m *ClusterMigrationController) rollbacking(ctx context.Context,
 
 	// 1. Send rollback events to source hubs to restore original configurations
 	fromHub := mcm.Spec.From
-	clusters := mcm.Spec.IncludedManagedClusters
+	clusters := GetClusterList(string(mcm.UID))
+
 	if !GetStarted(string(mcm.GetUID()), fromHub, migrationv1alpha1.PhaseRollbacking) {
 		log.Infof("sending rollback event to source hub: %s", fromHub)
 

--- a/manager/pkg/migration/migration_validating_test.go
+++ b/manager/pkg/migration/migration_validating_test.go
@@ -152,12 +152,18 @@ func TestValidating(t *testing.T) {
 			existingObjects: []client.Object{
 				&clusterv1.ManagedCluster{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "target-hub",
+						Name:        "target-hub",
+						Annotations: map[string]string{"addon.open-cluster-management.io/on-multicluster-hub": "true"},
+					},
+					Status: clusterv1.ManagedClusterStatus{
+						Conditions: []metav1.Condition{
+							{Type: "ManagedClusterConditionAvailable", Status: metav1.ConditionTrue},
+						},
 					},
 				},
 			},
 			expectedRequeue:         false,
-			expectedError:           false,
+			expectedError:           true,
 			description:             "Should fail when source hub is not found",
 			expectedPhase:           migrationv1alpha1.PhaseFailed,
 			expectedConditionStatus: metav1.ConditionFalse,
@@ -183,12 +189,18 @@ func TestValidating(t *testing.T) {
 			existingObjects: []client.Object{
 				&clusterv1.ManagedCluster{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "source-hub",
+						Name:        "source-hub",
+						Annotations: map[string]string{"addon.open-cluster-management.io/on-multicluster-hub": "true"},
+					},
+					Status: clusterv1.ManagedClusterStatus{
+						Conditions: []metav1.Condition{
+							{Type: "ManagedClusterConditionAvailable", Status: metav1.ConditionTrue},
+						},
 					},
 				},
 			},
 			expectedRequeue:         false,
-			expectedError:           false,
+			expectedError:           true,
 			description:             "Should fail when target hub is not found",
 			expectedPhase:           migrationv1alpha1.PhaseFailed,
 			expectedConditionStatus: metav1.ConditionFalse,
@@ -215,21 +227,33 @@ func TestValidating(t *testing.T) {
 			existingObjects: []client.Object{
 				&clusterv1.ManagedCluster{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "source-hub",
+						Name:        "source-hub",
+						Annotations: map[string]string{"addon.open-cluster-management.io/on-multicluster-hub": "true"},
+					},
+					Status: clusterv1.ManagedClusterStatus{
+						Conditions: []metav1.Condition{
+							{Type: "ManagedClusterConditionAvailable", Status: metav1.ConditionTrue},
+						},
 					},
 				},
 				&clusterv1.ManagedCluster{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "target-hub",
+						Name:        "target-hub",
+						Annotations: map[string]string{"addon.open-cluster-management.io/on-multicluster-hub": "true"},
+					},
+					Status: clusterv1.ManagedClusterStatus{
+						Conditions: []metav1.Condition{
+							{Type: "ManagedClusterConditionAvailable", Status: metav1.ConditionTrue},
+						},
 					},
 				},
 			},
 			expectedRequeue:         false,
-			expectedError:           false, // Actually no error, just failed phase
+			expectedError:           true, // Now returns error due to database connection failure
 			description:             "Should fail with invalid resources but hit database error first",
 			expectedPhase:           migrationv1alpha1.PhaseFailed,
 			expectedConditionStatus: metav1.ConditionFalse,
-			expectedConditionReason: "HubClusterInvalid",
+			expectedConditionReason: "ClusterNotFound",
 		},
 		{
 			name: "Should validate successfully with valid configuration",
@@ -252,21 +276,33 @@ func TestValidating(t *testing.T) {
 			existingObjects: []client.Object{
 				&clusterv1.ManagedCluster{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "source-hub",
+						Name:        "source-hub",
+						Annotations: map[string]string{"addon.open-cluster-management.io/on-multicluster-hub": "true"},
+					},
+					Status: clusterv1.ManagedClusterStatus{
+						Conditions: []metav1.Condition{
+							{Type: "ManagedClusterConditionAvailable", Status: metav1.ConditionTrue},
+						},
 					},
 				},
 				&clusterv1.ManagedCluster{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "target-hub",
+						Name:        "target-hub",
+						Annotations: map[string]string{"addon.open-cluster-management.io/on-multicluster-hub": "true"},
+					},
+					Status: clusterv1.ManagedClusterStatus{
+						Conditions: []metav1.Condition{
+							{Type: "ManagedClusterConditionAvailable", Status: metav1.ConditionTrue},
+						},
 					},
 				},
 			},
 			expectedRequeue:         false,
-			expectedError:           false, // Actually no error, just failed phase
+			expectedError:           true, // Now returns error due to database connection failure
 			description:             "Should attempt validation with valid configuration but hit database error",
 			expectedPhase:           migrationv1alpha1.PhaseFailed,
 			expectedConditionStatus: metav1.ConditionFalse,
-			expectedConditionReason: "HubClusterInvalid",
+			expectedConditionReason: "ClusterNotFound",
 		},
 	}
 

--- a/manager/pkg/status/handlers/clustermigartion/managedclustermigration_handler.go
+++ b/manager/pkg/status/handlers/clustermigartion/managedclustermigration_handler.go
@@ -79,6 +79,11 @@ func (k *managedClusterMigrationHandler) handle(ctx context.Context, evt *cloude
 		return fmt.Errorf("the hub %s should set the migrationId", hubClusterName)
 	}
 
+	// Store managed clusters if provided
+	if len(bundle.ManagedClusters) > 0 {
+		migration.SetClusterList(bundle.MigrationId, bundle.ManagedClusters)
+	}
+
 	if bundle.ErrMessage != "" {
 		migration.SetErrorMessage(bundle.MigrationId, hubClusterName, bundle.Stage, bundle.ErrMessage)
 	} else {

--- a/pkg/bundle/migration/managedcluster_migration.go
+++ b/pkg/bundle/migration/managedcluster_migration.go
@@ -20,6 +20,7 @@ type MigrationSourceBundle struct {
 	MigrationId     string         `json:"migrationId"`
 	Stage           string         `json:"stage"`
 	ToHub           string         `json:"toHub"`
+	PlacementName   string         `json:"placementName"`
 	ManagedClusters []string       `json:"managedClusters,omitempty"`
 	BootstrapSecret *corev1.Secret `json:"bootstrapSecret,omitempty"`
 	RollbackStage   string         `json:"rollbackStage,omitempty"` // Indicates which stage is being rolled back
@@ -38,11 +39,11 @@ type MigrationTargetBundle struct {
 
 // The bundle sent from the managed hubs to the global hub
 type MigrationStatusBundle struct {
-	MigrationId string `json:"migrationId"`
-	Stage       string `json:"stage"`
-	ErrMessage  string `json:"errMessage,omitempty"`
-	Resync      bool   `json:"resync,omitempty"`
-	// ManagedClusters []string `json:"managedClusters,omitempty"`
+	MigrationId     string   `json:"migrationId"`
+	Stage           string   `json:"stage"`
+	ErrMessage      string   `json:"errMessage,omitempty"`
+	Resync          bool     `json:"resync,omitempty"`
+	ManagedClusters []string `json:"managedClusters,omitempty"`
 }
 
 type MigrationResourceBundle struct {


### PR DESCRIPTION
## Summary
- Add support for placement-based cluster selection in migration validating stage
- Enhance MigrationSourceBundle and MigrationStatusBundle to include placement name and managed clusters list
- Implement cluster retrieval from placement decisions when placement name is provided

## Changes
- **agent/pkg/spec/syncers/migration_from_syncer.go**: Add validating stage handler and placement decision query logic
- **manager/pkg/migration/**: Update all migration stage handlers to support new placement name parameter
- **pkg/bundle/migration/**: Add placement name field to source bundle and managed clusters to status bundle
- **manager/pkg/status/handlers/**: Add cluster list storage in migration event status tracking

## Test plan
- [ ] Verify migration works with placement-based cluster selection
- [ ] Test fallback to spec-based cluster selection when placement is not provided
- [ ] Validate cluster list is properly retrieved from placement decisions
- [ ] Ensure backward compatibility with existing migration workflows

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Placement-aware migrations: events and status now include PlacementName and ManagedClusters to support placement-driven cluster resolution.

* **Improvements**
  * Per-migration cluster lists persisted across stages for consistent selection and propagation.
  * Validation rework: stricter hub gating, local-cluster detection, requeue semantics, and clearer migration-name logging.

* **Tests**
  * Added unit tests for placement resolution, placement-decision aggregation, cluster-list handling, and validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->