### PR TITLE
fix: remove ManagedClusterMigration finalizer and fix unit tests

### DIFF
--- a/manager/pkg/migration/migration_controller_test.go
+++ b/manager/pkg/migration/migration_controller_test.go
@@ -16,7 +16,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	migrationv1alpha1 "github.com/stolostron/multicluster-global-hub/operator/api/migration/v1alpha1"
-	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
@@ -334,7 +333,7 @@ func TestSelectAndPrepareMigration(t *testing.T) {
 						UID:               types.UID("deleting-uid"),
 						CreationTimestamp: metav1.Time{Time: time.Now()},
 						DeletionTimestamp: &metav1.Time{Time: time.Now()},
-						Finalizers:        []string{constants.ManagedClusterMigrationFinalizer},
+						Finalizers:        []string{"test-finalizer"},
 					},
 					Status: migrationv1alpha1.ManagedClusterMigrationStatus{
 						Phase: migrationv1alpha1.PhaseInitializing,

--- a/manager/pkg/migration/migration_utils.go
+++ b/manager/pkg/migration/migration_utils.go
@@ -106,10 +106,20 @@ func (m *ClusterMigrationController) UpdateStatusWithRetry(ctx context.Context,
 					return err
 				}
 			}
+			m.handleStatusCache(mcm)
 			return nil
 		}
 		return nil
 	})
+}
+
+func (m *ClusterMigrationController) handleStatusCache(mcm *migrationv1alpha1.ManagedClusterMigration) {
+	if mcm.Status.Phase == migrationv1alpha1.PhasePending {
+		AddMigrationStatus(string(mcm.GetUID()))
+	}
+	if mcm.Status.Phase == migrationv1alpha1.PhaseCompleted || mcm.Status.Phase == migrationv1alpha1.PhaseFailed {
+		RemoveMigrationStatus(string(mcm.GetUID()))
+	}
 }
 
 // UpdateFailureClustersToConfigMap updates the ConfigMap with failed cluster information.

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -219,8 +219,6 @@ const (
 )
 
 const (
-	// ManagedClusterMigrationFinalizer is the finalizer for managed cluster migration
-	ManagedClusterMigrationFinalizer = "global-hub.open-cluster-management.io/migration-cleanup"
 	// ManagedClusterMigrating is under migrating so the global hub agent ignore reporting the status for the cluster
 	ManagedClusterMigrating = "global-hub.open-cluster-management.io/migrating"
 	// KlusterletAddonConfigAnnotation is an annotation which contains klusterletAddonConfig object


### PR DESCRIPTION
## Summary
Remove the finalizer logic from ManagedClusterMigration controller and replace with lifecycle-based status cache management. This change also fixes the failing unit test that was referencing an undefined constant.

## Changes
- **Remove finalizer constant**: Deleted `ManagedClusterMigrationFinalizer` from `pkg/constants/constants.go`
- **Simplify controller logic**: Removed finalizer add/remove operations from the migration controller reconcile loop
- **Refactor status cache**: Moved status cache lifecycle management to `UpdateStatusWithRetry()` method in `migration_utils.go`
  - Add status on `PhasePending`
  - Remove status on `PhaseCompleted` or `PhaseFailed`
- **Fix unit test**: Updated test to use generic `"test-finalizer"` instead of the removed constant
- **Add early return**: Skip reconciliation when migration has deletion timestamp

## Test plan
- [x] Unit tests pass (`go test ./manager/pkg/migration/...`)
- [x] All migration controller tests passing
- [x] Fixed undefined constant compilation error

## Related Issue
ACM-25104

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Bug Fixes
  * Prevented migration resources from stalling during deletion by removing reliance on a cleanup finalizer and simplifying deletion handling.
  * Ensured migration status updates promptly on completion or failure, reducing stale "Pending" states.
* Refactor
  * Streamlined migration lifecycle flow and removed obsolete cleanup paths.
  * Added an in-memory status cache to keep reported phases current.
* Tests
  * Updated tests to reflect the simplified deletion and status behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->