### PR TITLE
fix: add missing return statement in UpdateFailureClustersToConfigMap

### DIFF
--- a/manager/pkg/migration/migration_utils.go
+++ b/manager/pkg/migration/migration_utils.go
@@ -141,6 +141,7 @@ func (m *ClusterMigrationController) UpdateFailureClustersToConfigMap(ctx contex
 			}); err != nil {
 			return fmt.Errorf("failed to store clusters to ConfigMap: %w", err)
 		}
+		return nil
 	}
 
 	// failedClusters = allClusters - successClusters


### PR DESCRIPTION
## Summary
Adds missing return statement in `UpdateFailureClustersToConfigMap` when handling the case where all clusters fail migration (successClusters is empty).

## Problem
The function was missing an explicit return after storing failed clusters to ConfigMap. This could lead to continuing execution and potentially processing the same clusters again in the subsequent code block, which could cause duplicate processing or unexpected behavior.

## Changes
- Added explicit `return nil` statement at [manager/pkg/migration/migration_utils.go:144](manager/pkg/migration/migration_utils.go#L144) after successfully storing all failed clusters when there are no successful clusters

## Related Issue
- Jira: https://issues.redhat.com/browse/ACM-25606

## Test plan
- [x] Code review
- [x] Logic verified - ensures early exit when all clusters have failed
- [ ] Manual testing with migration scenarios

## Checklist
- [x] Code follows project conventions
- [x] Change is minimal and focused
- [x] Commit includes DCO sign-off
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cluster migration configuration handling to correctly process scenarios where no successful clusters are available, enhancing system efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->